### PR TITLE
2016

### DIFF
--- a/templates/default/arguments.erb
+++ b/templates/default/arguments.erb
@@ -112,7 +112,9 @@
 --smbidmapgid=<%= node['authconfig']['winbind']['smb']['idmapgid'] %>
 --winbindseparator=<%= node['authconfig']['winbind']['separator'] %>
 --winbindtemplatehomedir=<%= node['authconfig']['winbind']['template']['homedir'] %>
---winbindtemplateprimarygroup=<%= node['authconfig']['winbind']['template']['primarygroup'] %>
+<% if node['platform_version'].to_i < 7 -%>
+	--winbindtemplateprimarygroup=<%= node['authconfig']['winbind']['template']['primarygroup'] %>
+<% end -%>
 --winbindtemplateshell=<%= node['authconfig']['winbind']['template']['shell'] %>
 <% if node['authconfig']['winbind']['usedefaultdomain'] -%>
 	--enablewinbindusedefaultdomain


### PR DESCRIPTION
---winbindtemplateprimarygroup was removed as an option as of authconfig 6.2.8-11, although it is mentioned as being "unusable" previous to this. This skips that option for centos7 and above, which throw errors when trying to use said option.